### PR TITLE
Fix class name to be PSR-4 compatible

### DIFF
--- a/src/ID3Parser.php
+++ b/src/ID3Parser.php
@@ -8,7 +8,7 @@
 
 namespace ID3Parser;
 
-use ID3Parser\getID3\getID3;
+use ID3Parser\getID3\getid3;
 
 class ID3Parser {
 	/**
@@ -16,7 +16,7 @@ class ID3Parser {
 	 * @return array
 	 */
 	public function analyze($fileName) {
-		$getID3 = new getID3();
+		$getID3 = new getid3();
 		return $getID3->analyze($fileName);
 	}
 }

--- a/src/getID3/getid3.php
+++ b/src/getID3/getid3.php
@@ -8,7 +8,7 @@
 
 namespace ID3Parser\getID3;
 
-class getID3 {
+class getid3 {
 	// public: Settings
 	private $encoding        = 'UTF-8';        // CASE SENSITIVE! - i.e. (must be supported by iconv()). Examples:  ISO-8859-1  UTF-8  UTF-16  UTF-16BE
 


### PR DESCRIPTION
The class and file names are case sensitive. This fixes the discrepancy and allows autoloading of getid3 class.